### PR TITLE
Enable explicit API mode, add explicit visibility and typing to comply

### DIFF
--- a/kite/build.gradle
+++ b/kite/build.gradle
@@ -28,3 +28,12 @@ dependencies {
     testImplementation deps.test.mockito_core
     testImplementation deps.test.truth
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        freeCompilerArgs += [
+                '-progressive',
+                '-Xexplicit-api=strict',
+        ]
+    }
+}

--- a/kite/src/main/kotlin/com/cioccarellia/kite/Kite.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/Kite.kt
@@ -25,6 +25,8 @@ import android.util.TypedValue
 import android.view.animation.Animation
 import android.view.animation.Interpolator
 import androidx.annotation.RestrictTo
+import com.cioccarellia.kite.resparser.KiteCustomResParser
+import com.cioccarellia.kite.resparser.KiteResParser
 import com.cioccarellia.kite.resparser.compat.KiteColorStateLists
 import com.cioccarellia.kite.resparser.compat.KiteColors
 import com.cioccarellia.kite.resparser.compat.KiteDrawables
@@ -35,11 +37,11 @@ import com.cioccarellia.kite.resparser.custom.KiteInterpolators
 import com.cioccarellia.kite.resparser.resources.*
 import java.io.InputStream
 
-object Kite {
+public object Kite {
     /**
      * Initialized Kite
      * */
-    fun fly(context: Context) {
+    public fun fly(context: Context) {
         this.context = context
     }
 
@@ -51,124 +53,124 @@ object Kite {
      * [Context.getString()] is used to resolve the id.
      * There is also a vararg variant which accepts format arguments, and maps to the appropriate [Context.getString()] function.
      * */
-    val string by lazy { KiteStrings() }
+    public val string: KiteResParser<Int, String> by lazy { KiteStrings() }
 
     /**
      * Fetches [String]s Plurals from resources, given the [String] id and the [Int] quantity.
      * [Resources.getQuantityString()] is used to resolve the id.
      * There is also a vararg variant which accepts format arguments, and maps to the appropriate [Resources.getQuantityString()] function.
      * */
-    val plural by lazy { KitePlurals() }
+    public val plural: KiteCustomResParser<Int, String> by lazy { KitePlurals() }
 
     /**
      * Fetches [CharSequence] Texts from resources.
      * [Context.getText()] is used to resolve the id.
      * */
-    val text by lazy { KiteTexts() }
+    public val text: KiteResParser<Int, CharSequence> by lazy { KiteTexts() }
 
     /**
      * Fetches color [Int]s from resources.
      * [ContextCompat.getColor()] is used to resolve the id.
      * */
-    val color by lazy { KiteColors() }
+    public val color: KiteResParser<Int, Int> by lazy { KiteColors() }
 
 
     /**
      * Fetches [ColorStateList]s from resources.
      * [ContextCompat.getColorStateList()] is used to resolve the id.
      * */
-    val colorStateList by lazy { KiteColorStateLists() }
+    public val colorStateList: KiteResParser<Int, ColorStateList> by lazy { KiteColorStateLists() }
 
     /**
      * Fetches [Boolean]s from resources.
      * [Resources.getBoolean()] is used to resolve the id.
      * */
-    val bools by lazy { KiteBools() }
+    public val bools: KiteResParser<Int, Boolean> by lazy { KiteBools() }
 
     /**
      * Fetches ID [Int]s from resources, given the definition type and package.
      * [Resources.getIdentifier()] is used to resolve the id.
      * */
-    val identifier by lazy { KiteIdentifier() }
+    public val identifier: KiteCustomResParser<String, Int> by lazy { KiteIdentifier() }
 
     /**
      * Fetches [Drawable]s from resources.
      * [ContextCompat.getDrawable()] is used to resolve the id.
      * There is also a variant which accepts a [Resources.Theme?] arguments, and maps to the [Resources.getDrawable()] function.
      * */
-    val drawable by lazy { KiteDrawables() }
+    public val drawable: KiteResParser<Int, Drawable> by lazy { KiteDrawables() }
 
     /**
      * Fetches [Animation]s from resources.
      * [AnimationUtils.loadAnimation()] is used to resolve the id.
      * */
-    val animation by lazy { KiteAnimations() }
+    public val animation: KiteResParser<Int, Animation> by lazy { KiteAnimations() }
 
     /**
      * Fetches [Interpolator]s from resources.
      * [AnimationUtils.loadInterpolator()] is used to resolve the id.
      * */
-    val interpolator by lazy { KiteInterpolators() }
+    public val interpolator: KiteResParser<Int, Interpolator> by lazy { KiteInterpolators() }
 
     /**
      * Fetches [IntArray]s from resources.
      * [Resources.getIntArray()] is used to resolve the id.
      * */
-    val intArray by lazy { KiteIntArrays() }
+    public val intArray: KiteResParser<Int, IntArray> by lazy { KiteIntArrays() }
 
     /**
      * Fetches String Arrays ([Array<String>]) from resources.
      * [Resources.getStringArray()] is used to resolve the id.
      * */
-    val stringArray by lazy { KiteStringArrays() }
+    public val stringArray: KiteResParser<Int, Array<out String>> by lazy { KiteStringArrays() }
 
     /**
      * Fetches [TypedArray]s from resources.
      * [Resources.obtainTypedArray()] is used to resolve the id.
      * */
-    val typedArray by lazy { KiteTypedArrays() }
+    public val typedArray: KiteResParser<Int, TypedArray> by lazy { KiteTypedArrays() }
 
     /**
      * Fetches Dimension [Float]s from resources.
      * [Resources.getDimension()] is used to resolve the id.
      * */
-    val dimension by lazy { KiteDimensions() }
+    public val dimension: KiteResParser<Int, Float> by lazy { KiteDimensions() }
 
     /**
      * Fetches [Int]s from resources.
      * [Resources.getInteger()] is used to resolve the id.
      * */
-    val integer by lazy { KiteIntegers() }
+    public val integer: KiteResParser<Int, Int> by lazy { KiteIntegers() }
 
     /**
      * Fetches fractions [Float]s from resources, given the value base and the parent value base.
      * [Resources.getFraction()] is used to resolve the id.
      * */
-    val fraction by lazy { KiteFraction() }
+    public val fraction: KiteCustomResParser<Int, Float> by lazy { KiteFraction() }
 
     /**
      * Fetches Layout [XmlResourceParser]s from resources.
      * [Resources.getLayout()] is used to resolve the id.
      * */
-    val layout by lazy { KiteLayouts() }
+    public val layout: KiteResParser<Int, XmlResourceParser> by lazy { KiteLayouts() }
 
     /**
      * Fetches [InputStream]s from resources.
      * [Resources.openRawResource()] is used to resolve the id.
      * There is also a parameterized variant which accepts a [TypedValue], which maps to the appropriate [Resources.openRawResource()] function.
      * */
-    val raw by lazy { KiteRaws() }
+    public val raw: KiteResParser<Int, InputStream> by lazy { KiteRaws() }
 
     /**
      * Fetches Layout [XmlResourceParser]s from resources.
      * [Resources.getXml()] is used to resolve the id.
      * */
-    val xml by lazy { KiteXmls() }
+    public val xml: KiteResParser<Int, XmlResourceParser> by lazy { KiteXmls() }
 
     /**
      * Requires API 26 (O)
      * Fetches Layout [Typeface]s from resources.
      * [Resources.getFont()] is used to resolve the id.
      * */
-    val font by lazy { KiteFonts() }
+    public val font: KiteResParser<Int, Typeface> by lazy { KiteFonts() }
 }

--- a/kite/src/main/kotlin/com/cioccarellia/kite/extensions/KiteContextExtensions.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/extensions/KiteContextExtensions.kt
@@ -23,13 +23,13 @@ import com.cioccarellia.kite.resparser.KiteParser
 /**
  * @return kite [Context] reference
  * */
-fun getKiteContext() = Kite.context
+public fun getKiteContext(): Context = Kite.context
 
 /**
  * Permanently changes the context used by kite
  * @param [context]     The context to be set as the new kite context
  * */
-fun changeKiteContext(context: Context) {
+public fun changeKiteContext(context: Context) {
     Kite.context = context
 }
 
@@ -38,7 +38,7 @@ fun changeKiteContext(context: Context) {
  * @param [context]     The context to be set as the new kite context
  * @return [T]          KiteParser instance referencing the new context
  * */
-fun <T : KiteParser> T.changeContext(context: Context): T = apply {
+public fun <T : KiteParser> T.changeContext(context: Context): T = apply {
     Kite.context = context
 }
 
@@ -49,7 +49,7 @@ fun <T : KiteParser> T.changeContext(context: Context): T = apply {
  * @param [block]       The lambda to be executed
  * @return [T]          KiteParser instance, referencing the same context it was passed with
  * */
-fun <T : KiteParser, R> T.runWith(context: Context, block: T.() -> R): R = run {
+public fun <T : KiteParser, R> T.runWith(context: Context, block: T.() -> R): R = run {
     val previousContext = getKiteContext()
     changeContext(context).block().also { changeContext(previousContext) }
 }

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/KiteCustomResParser.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/KiteCustomResParser.kt
@@ -18,4 +18,4 @@ package com.cioccarellia.kite.resparser
 /**
  * [KiteParser] which has precisely 1 input and 1 output
  * */
-abstract class KiteCustomResParser<in R, out O> : KiteParser()
+public abstract class KiteCustomResParser<in R, out O> : KiteParser()

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/KiteParser.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/KiteParser.kt
@@ -22,7 +22,7 @@ import com.cioccarellia.kite.Kite
 /**
  * Represents a Kite parser entity
  * */
-abstract class KiteParser {
+public abstract class KiteParser {
     internal var kiteContext: Context
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         get() {

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/KiteResParser.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/KiteResParser.kt
@@ -18,6 +18,6 @@ package com.cioccarellia.kite.resparser
 /**
  * [KiteParser] which has precisely 1 input and 1 output
  * */
-abstract class KiteResParser<in R, out O> : KiteParser() {
-    abstract operator fun get(resource: R): O
+public abstract class KiteResParser<in R, out O> : KiteParser() {
+    public abstract operator fun get(resource: R): O
 }

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/compat/KiteColorStateLists.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/compat/KiteColorStateLists.kt
@@ -26,7 +26,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteColorStateLists Implementation
  * */
-class KiteColorStateLists : KiteResParser<@ColorRes Int, ColorStateList>() {
+internal class KiteColorStateLists : KiteResParser<@ColorRes Int, ColorStateList>() {
     override operator fun get(
         @ColorRes @IntRange(from = 1) colorStateList: Int
     ): ColorStateList = ContextCompat.getColorStateList(kiteContext, colorStateList)!!

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/compat/KiteColors.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/compat/KiteColors.kt
@@ -26,7 +26,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteColors Implementation
  * */
-class KiteColors : KiteResParser<@ColorRes Int, @ColorInt Int>() {
+internal class KiteColors : KiteResParser<@ColorRes Int, @ColorInt Int>() {
     @ColorInt
     override operator fun get(
         @ColorRes @IntRange(from = 1) color: Int

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/compat/KiteDrawables.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/compat/KiteDrawables.kt
@@ -29,7 +29,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteDrawables Implementation
  * */
-class KiteDrawables : KiteResParser<@DrawableRes Int, Drawable>() {
+internal class KiteDrawables : KiteResParser<@DrawableRes Int, Drawable>() {
     override operator fun get(
         @DrawableRes @IntRange(from = 1) drawable: Int
     ): Drawable = ContextCompat.getDrawable(kiteContext, drawable)!!

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/context/KiteStrings.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/context/KiteStrings.kt
@@ -24,7 +24,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteStrings Implementation
  * */
-class KiteStrings : KiteResParser<@StringRes Int, String>() {
+internal class KiteStrings : KiteResParser<@StringRes Int, String>() {
     override operator fun get(
         @StringRes @IntRange(from = 1) string: Int
     ): String = kiteContext.getString(string)

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/context/KiteTexts.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/context/KiteTexts.kt
@@ -24,7 +24,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteTexts Implementation
  * */
-class KiteTexts : KiteResParser<@StringRes Int, CharSequence>() {
+internal class KiteTexts : KiteResParser<@StringRes Int, CharSequence>() {
     override operator fun get(
         @StringRes @IntRange(from = 1) text: Int
     ): CharSequence = kiteContext.getText(text)

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/custom/KiteAnimations.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/custom/KiteAnimations.kt
@@ -26,7 +26,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteAnimations Implementation
  * */
-class KiteAnimations : KiteResParser<@AnimRes Int, Animation>() {
+internal class KiteAnimations : KiteResParser<@AnimRes Int, Animation>() {
     override operator fun get(
         @AnimRes @IntRange(from = 1) animation: Int
     ): Animation = AnimationUtils.loadAnimation(kiteContext, animation)!!

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/custom/KiteInterpolators.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/custom/KiteInterpolators.kt
@@ -26,7 +26,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteInterpolators Implementation
  * */
-class KiteInterpolators : KiteResParser<@InterpolatorRes Int, Interpolator>() {
+internal class KiteInterpolators : KiteResParser<@InterpolatorRes Int, Interpolator>() {
     override operator fun get(
         @InterpolatorRes @IntRange(from = 1) animation: Int
     ): Interpolator = AnimationUtils.loadInterpolator(kiteContext, animation)!!

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteBools.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteBools.kt
@@ -24,7 +24,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteBools Implementation
  * */
-class KiteBools : KiteResParser<@BoolRes Int, Boolean>() {
+internal class KiteBools : KiteResParser<@BoolRes Int, Boolean>() {
     override operator fun get(
         @BoolRes @IntRange(from = 1) boolean: Int
     ): Boolean = kiteContext.resources.getBoolean(boolean)

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteDimensions.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteDimensions.kt
@@ -24,7 +24,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteDimens Implementation
  * */
-class KiteDimensions : KiteResParser<@DimenRes Int, Float>() {
+internal class KiteDimensions : KiteResParser<@DimenRes Int, Float>() {
     override operator fun get(
         @DimenRes @IntRange(from = 1) dimension: Int
     ): Float = kiteContext.resources.getDimension(dimension)

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteFonts.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteFonts.kt
@@ -27,7 +27,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteFonts Implementation
  * */
-class KiteFonts : KiteResParser<@FontRes Int, Typeface>() {
+internal class KiteFonts : KiteResParser<@FontRes Int, Typeface>() {
     @RequiresApi(Build.VERSION_CODES.O)
     override operator fun get(
         @FontRes @IntRange(from = 1) font: Int

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteFraction.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteFraction.kt
@@ -24,7 +24,7 @@ import com.cioccarellia.kite.resparser.KiteCustomResParser
 /**
  * KiteFraction Implementation
  * */
-class KiteFraction : KiteCustomResParser<@FractionRes Int, Float>() {
+internal class KiteFraction : KiteCustomResParser<@FractionRes Int, Float>() {
     operator fun get(
         @FractionRes @IntRange(from = 1) fraction: Int,
         @IntRange(from = 2) base: Int,

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteIdentifier.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteIdentifier.kt
@@ -22,7 +22,7 @@ import com.cioccarellia.kite.resparser.KiteCustomResParser
 /**
  * KiteIdentifier Implementation
  * */
-class KiteIdentifier : KiteCustomResParser<String, Int>() {
+internal class KiteIdentifier : KiteCustomResParser<String, Int>() {
     operator fun get(
         name: String,
         defType: String,

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteIntArrays.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteIntArrays.kt
@@ -24,7 +24,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteIntArrays Implementation
  * */
-class KiteIntArrays : KiteResParser<@ArrayRes Int, IntArray>() {
+internal class KiteIntArrays : KiteResParser<@ArrayRes Int, IntArray>() {
     override operator fun get(
         @ArrayRes @IntRange(from = 1) intArray: Int
     ): IntArray = kiteContext.resources.getIntArray(intArray)

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteIntegers.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteIntegers.kt
@@ -24,7 +24,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteIntegers Implementation
  * */
-class KiteIntegers : KiteResParser<@IntegerRes Int, Int>() {
+internal class KiteIntegers : KiteResParser<@IntegerRes Int, Int>() {
     override operator fun get(
         @IntegerRes @IntRange(from = 1) integer: Int
     ): Int = kiteContext.resources.getInteger(integer)

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteLayouts.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteLayouts.kt
@@ -25,7 +25,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteLayouts Implementation
  * */
-class KiteLayouts : KiteResParser<@LayoutRes Int, XmlResourceParser>() {
+internal class KiteLayouts : KiteResParser<@LayoutRes Int, XmlResourceParser>() {
     override operator fun get(
         @LayoutRes @IntRange(from = 1) layout: Int
     ): XmlResourceParser = kiteContext.resources.getLayout(layout)

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KitePlurals.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KitePlurals.kt
@@ -24,7 +24,7 @@ import com.cioccarellia.kite.resparser.KiteCustomResParser
 /**
  * KitePlurals Implementation
  * */
-class KitePlurals : KiteCustomResParser<@PluralsRes Int, String>() {
+internal class KitePlurals : KiteCustomResParser<@PluralsRes Int, String>() {
     operator fun get(
         @PluralsRes @IntRange(from = 1) plurals: Int,
         quantity: Int

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteRaws.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteRaws.kt
@@ -26,7 +26,7 @@ import java.io.InputStream
 /**
  * KiteRaws Implementation
  * */
-class KiteRaws : KiteResParser<@RawRes Int, InputStream>() {
+internal class KiteRaws : KiteResParser<@RawRes Int, InputStream>() {
     override operator fun get(
         @RawRes @IntRange(from = 1) raw: Int
     ): InputStream = kiteContext.resources.openRawResource(raw)

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteStringArrays.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteStringArrays.kt
@@ -24,7 +24,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteStringArrays Implementation
  * */
-class KiteStringArrays : KiteResParser<@ArrayRes Int, Array<out String>>() {
+internal class KiteStringArrays : KiteResParser<@ArrayRes Int, Array<out String>>() {
     override operator fun get(
         @ArrayRes @IntRange(from = 1) stringArray: Int
     ): Array<out String> = kiteContext.resources.getStringArray(stringArray)

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteTypedArrays.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteTypedArrays.kt
@@ -25,7 +25,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteTypedArrays Implementation
  * */
-class KiteTypedArrays : KiteResParser<@ArrayRes Int, TypedArray>() {
+internal class KiteTypedArrays : KiteResParser<@ArrayRes Int, TypedArray>() {
     override operator fun get(
         @ArrayRes @IntRange(from = 1) typedArray: Int
     ): TypedArray = kiteContext.resources.obtainTypedArray(typedArray)

--- a/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteXmls.kt
+++ b/kite/src/main/kotlin/com/cioccarellia/kite/resparser/resources/KiteXmls.kt
@@ -25,7 +25,7 @@ import com.cioccarellia.kite.resparser.KiteResParser
 /**
  * KiteXmls Implementation
  * */
-class KiteXmls : KiteResParser<@XmlRes Int, XmlResourceParser>() {
+internal class KiteXmls : KiteResParser<@XmlRes Int, XmlResourceParser>() {
     override operator fun get(
         @XmlRes @IntRange(from = 1) xml: Int
     ): XmlResourceParser = kiteContext.resources.getXml(xml)


### PR DESCRIPTION
This PR enables [explicit API mode](https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors), which requires explicit visibility modifiers for all declarations, and explicit types for public declarations. I made educated guesses about what you'd want public and not public in the library, most importantly, made all `KiteResParser` implementations `internal`, only exposing them through the interface.

Also enables [progressive mode](https://kotlinlang.org/docs/reference/whatsnew13.html#progressive-mode) as a bonus, as that's also a compiler property that can be specified the same way.